### PR TITLE
Fixed Live version link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A pure, lightweight, and beautiful share modal for Vue 3
 
 ## 🪁 Live version
 You can see the live version here:  
-[https://sttatusx.github.io/vue-share-modal/](https://sttatusx.github.io/vue-share-modal/)
+[https://freakingeek.github.io/vue-share-modal/](https://freakingeek.github.io/vue-share-modal/)
 
   ‌
 


### PR DESCRIPTION
It seems that this link pointed to repository that didn't exist at current moment. However changing account name to repo owner it seems everything works fine.